### PR TITLE
Fix recovery compass

### DIFF
--- a/bin/development/src/main/java/net/hollowcube/mapmaker/dev/DevServer.java
+++ b/bin/development/src/main/java/net/hollowcube/mapmaker/dev/DevServer.java
@@ -63,6 +63,7 @@ import net.minestom.server.entity.metadata.display.TextDisplayMeta;
 import net.minestom.server.event.player.*;
 import net.minestom.server.extras.MojangAuth;
 import net.minestom.server.extras.velocity.VelocityProxy;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.client.play.ClientCommandChatPacket;
@@ -385,8 +386,11 @@ public class DevServer {
     }
 
     private void handleLogin(PlayerLoginEvent event) {
-        event.setSpawningInstance(hub.world().instance());
-        event.getPlayer().setRespawnPoint(new Pos(0.5, 40, 0.5, 90, 0));
+        Instance instance = hub.world().instance();
+        Pos pos = new Pos(0.5, 40, 0.5, 90, 0);
+        event.setSpawningInstance(instance);
+        event.getPlayer().setRespawnPoint(pos);
+        event.getPlayer().setDeathLocation(instance.getDimensionType(), pos);
     }
 
     private void handleDisconnect(PlayerDisconnectEvent event) {
@@ -704,7 +708,6 @@ public class DevServer {
 //                .delay(5, net.minestom.server.utils.time.TimeUnit.SECOND)
 //                .repeat(5, net.minestom.server.utils.time.TimeUnit.SECOND)
 //                .schedule();
-
     }
 
     private void broadcastTabHeaderAndFooter() {

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/instance/MapInstance.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/instance/MapInstance.java
@@ -61,12 +61,12 @@ public class MapInstance extends InstanceContainer {
 
 
 
-    public MapInstance(@NotNull String dimensionName) {
-        this(dimensionName, DimensionTypes.FULL_BRIGHT);
+    public MapInstance() {
+        this(DimensionTypes.FULL_BRIGHT);
     }
 
-    public MapInstance(@NotNull String dimensionName, @NotNull DimensionType dimensionType) {
-        super(UUID.randomUUID(), dimensionType, null, NamespaceID.from(dimensionName));
+    public MapInstance(@NotNull DimensionType dimensionType) {
+        super(UUID.randomUUID(), dimensionType, null, dimensionType.getName());
 
         setTimeRate(0); //todo eventually this should be a map setting
 

--- a/modules/hub/src/main/java/net/hollowcube/mapmaker/hub/world/HubWorld.java
+++ b/modules/hub/src/main/java/net/hollowcube/mapmaker/hub/world/HubWorld.java
@@ -44,7 +44,7 @@ public class HubWorld {
     public HubWorld(@NotNull HubServer server) {
         this.server = server;
 
-        instance = new MapInstance("mapmaker:hub");
+        instance = new MapInstance();
         instance.setTag(MARKER, true);
         instance.setTag(THIS_TAG, this);
         instance.setGenerator(HubGenerators.stoneWorld());

--- a/modules/map/src/main/java/net/hollowcube/map/world/EditingMapWorld.java
+++ b/modules/map/src/main/java/net/hollowcube/map/world/EditingMapWorld.java
@@ -75,7 +75,7 @@ public class EditingMapWorld implements InternalMapWorld {
         this.map = map;
         this.flags |= FLAG_EDITING;
 
-        instance = new MapInstance(getDimensionName());
+        instance = new MapInstance();
         instance.setGenerator(MapGenerators.voidWorld());
         instance.setTag(SELF_TAG, this);
 

--- a/modules/map/src/main/java/net/hollowcube/map/world/PlayingMapWorld.java
+++ b/modules/map/src/main/java/net/hollowcube/map/world/PlayingMapWorld.java
@@ -73,7 +73,7 @@ public class PlayingMapWorld implements InternalMapWorld {
         this.map = map;
         this.flags |= FLAG_PLAYING;
 
-        instance = new MapInstance(getDimensionName());
+        instance = new MapInstance();
         instance.setGenerator(MapGenerators.voidWorld());
         instance.setTag(SELF_TAG, this);
 


### PR DESCRIPTION
Minecraft will have the recovery compass spin randomly if the Instance's dimensionName variable does not match the instance's dimensionType.name variable. This PR fixes the issue on mapmaker by removing the mismatch.