### PR TITLE
fix: Axe Tool stripping logs

### DIFF
--- a/modules/map/src/main/java/net/hollowcube/map/block/InteractionRules.java
+++ b/modules/map/src/main/java/net/hollowcube/map/block/InteractionRules.java
@@ -83,6 +83,7 @@ public class InteractionRules {
             // Rule was not applied, so continue to item rules
         }
 
+        if (event.isBlockingItemUse()) return; // Skip item rules if the event blocks item use
         rule = itemRules.get(itemStack.material().id());
         if (rule == null || !rule.sneakState().test(player.isSneaking(), !itemStack.isAir())) return;
 

--- a/modules/terraform/src/main/java/net/hollowcube/terraform/tool/ToolHandler.java
+++ b/modules/terraform/src/main/java/net/hollowcube/terraform/tool/ToolHandler.java
@@ -3,10 +3,7 @@ package net.hollowcube.terraform.tool;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventFilter;
 import net.minestom.server.event.EventNode;
-import net.minestom.server.event.player.PlayerBlockBreakEvent;
-import net.minestom.server.event.player.PlayerBlockPlaceEvent;
-import net.minestom.server.event.player.PlayerUseItemEvent;
-import net.minestom.server.event.player.PlayerUseItemOnBlockEvent;
+import net.minestom.server.event.player.*;
 import net.minestom.server.event.trait.InstanceEvent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -30,6 +27,7 @@ public class ToolHandler {
     private final EventNode<InstanceEvent> eventNode = EventNode.type("terraform:tool/handler", EventFilter.INSTANCE)
             .addListener(PlayerBlockBreakEvent.class, this::handleBreakBlock)
             .addListener(PlayerUseItemOnBlockEvent.class, this::handleUseItemOnBlock)
+            .addListener(PlayerBlockInteractEvent.class, this::handleBlockInteract)
             .addListener(PlayerUseItemEvent.class, this::handleUseItem)
             .addListener(PlayerBlockPlaceEvent.class, this::handlePlaceBlock);
 
@@ -131,6 +129,14 @@ public class ToolHandler {
                 event.getBlockFace(),
                 null
         ));
+    }
+
+    private void handleBlockInteract(@NotNull PlayerBlockInteractEvent event) {
+        var itemStack = event.getPlayer().getItemInHand(event.getHand());
+        var tool = getTool(itemStack);
+        if (tool == null || (tool.flags() & BuiltinTool.RIGHT_CLICK_BLOCK) == 0) return;
+
+        event.setCancelled(true);
     }
 
     private void handlePlaceBlock(@NotNull PlayerBlockPlaceEvent event) {


### PR DESCRIPTION
Cancel the block interaction event so it doesn't fire the AxeInteraction rule if you're holding a tool.

This preserves the right click functionality (e.g. set pos 2), but doesn't allow the AxeInteractionRule to be called.