### PR TITLE
AbstractHttpService hostname & BaseConsumer changes

### DIFF
--- a/.ijrun/DevServer (local).run.xml
+++ b/.ijrun/DevServer (local).run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="DevServer (local)" type="BlazeCommandRunConfigurationType" factoryName="Bazel Command">
-    <blaze-settings handler-id="BlazeJavaRunConfigurationHandlerProvider" kind="java_binary" blaze-command="run" blaze-binary="/opt/homebrew/bin/bazel">
+    <blaze-settings handler-id="BlazeJavaRunConfigurationHandlerProvider" kind="java_binary" blaze-command="run">
       <blaze-target>//bin/development:development</blaze-target>
       <blaze-user-flag>--define</blaze-user-flag>
       <blaze-user-flag>RESOURCE_PACK_SHA=dev</blaze-user-flag>

--- a/bin/proxy_plugin/src/main/java/net/hollowcube/proxy/ProxyPlugin.java
+++ b/bin/proxy_plugin/src/main/java/net/hollowcube/proxy/ProxyPlugin.java
@@ -18,6 +18,7 @@ import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.api.util.GameProfile;
+import net.hollowcube.common.ServerRuntime;
 import net.hollowcube.mapmaker.player.PlayerSkin;
 import net.hollowcube.mapmaker.player.SessionCreateRequestV2;
 import net.hollowcube.mapmaker.player.SessionService;
@@ -102,7 +103,7 @@ public class ProxyPlugin {
             var pd = sessionService.createSessionV2(
                     player.getUniqueId().toString(),
                     new SessionCreateRequestV2(
-                            AbstractHttpService.hostname,
+                            ServerRuntime.getRuntime().hostname(),
                             player.getUsername(),
                             player.getRemoteAddress().getAddress().getHostAddress(),
                             new PlayerSkin(skinTexture, skinSignature)

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/chat/ChatMessageListener.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/chat/ChatMessageListener.java
@@ -62,7 +62,7 @@ public class ChatMessageListener extends BaseConsumer<ChatMessageData> implement
     private final FriendlyProducer producer;
 
     public ChatMessageListener(@NotNull SessionManager sessionManager, @NotNull PlayerService playerService, @NotNull MapService mapService, @NotNull String kafkaBrokers) {
-        super(CHAT_OUT_TOPIC, "chat", ChatMessageListener::fromJson, kafkaBrokers);
+        super(CHAT_OUT_TOPIC, ChatMessageListener::fromJson, kafkaBrokers);
         this.sessionManager = sessionManager;
         this.playerService = playerService;
         this.mapService = mapService;

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/invite/MapInviteAcceptedOrRejectedListener.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/invite/MapInviteAcceptedOrRejectedListener.java
@@ -1,12 +1,12 @@
 package net.hollowcube.mapmaker.invite;
 
 import com.google.gson.Gson;
-import net.hollowcube.mapmaker.map.runtime.ServerBridge;
-import net.hollowcube.mapmaker.map.runtime.ServerBridge.JoinMapState;
 import net.hollowcube.mapmaker.invite.types.InviteType;
 import net.hollowcube.mapmaker.invite.types.MapInviteAcceptedOrRejectedMessage;
 import net.hollowcube.mapmaker.kafka.BaseConsumer;
 import net.hollowcube.mapmaker.map.MapService;
+import net.hollowcube.mapmaker.map.runtime.ServerBridge;
+import net.hollowcube.mapmaker.map.runtime.ServerBridge.JoinMapState;
 import net.hollowcube.mapmaker.player.PlayerService;
 import net.hollowcube.mapmaker.session.SessionManager;
 import net.hollowcube.mapmaker.util.AbstractHttpService;
@@ -33,7 +33,7 @@ public final class MapInviteAcceptedOrRejectedListener extends BaseConsumer<MapI
     public MapInviteAcceptedOrRejectedListener(@NotNull MapService mapService, @NotNull PlayerService playerService,
                                                @NotNull SessionManager sessionManager,
                                                @NotNull ServerBridge serverBridge, @NotNull String kafkaBrokers) {
-        super(INVITE_ACCEPT_REJECT_TOPIC, "invites", MapInviteAcceptedOrRejectedListener::fromJson, kafkaBrokers);
+        super(INVITE_ACCEPT_REJECT_TOPIC, MapInviteAcceptedOrRejectedListener::fromJson, kafkaBrokers);
         this.mapService = mapService;
         this.playerService = playerService;
         this.sessionManager = sessionManager;

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/invite/MapInviteListener.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/invite/MapInviteListener.java
@@ -29,7 +29,7 @@ public final class MapInviteListener extends BaseConsumer<CreatedMapInviteMessag
 
     public MapInviteListener(@NotNull MapService mapService, @NotNull PlayerService playerService,
                              @NotNull SessionManager sessionManager, @NotNull String kafkaBrokers) {
-        super(INVITE_TOPIC, "invites", MapInviteListener::fromJson, kafkaBrokers);
+        super(INVITE_TOPIC, MapInviteListener::fromJson, kafkaBrokers);
         this.mapService = mapService;
         this.playerService = playerService;
         this.sessionManager = sessionManager;

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/kafka/BaseConsumer.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/kafka/BaseConsumer.java
@@ -27,7 +27,7 @@ public abstract class BaseConsumer<T> implements AutoCloseable {
     // will see it, close, and then complete it allowing shutdown to finalize.
     private volatile CompletableFuture<Void> closeFuture = null;
 
-    protected BaseConsumer(@NotNull String topic, @NotNull String groupId,
+    protected BaseConsumer(@NotNull String topic,
                            @NotNull Function<String, T> deserializer,
                            @NotNull String bootstrapServers) {
         if (bootstrapServers.isEmpty()) {

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/map/MapMgmtConsumer.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/map/MapMgmtConsumer.java
@@ -1,6 +1,5 @@
 package net.hollowcube.mapmaker.map;
 
-import net.hollowcube.common.ServerRuntime;
 import net.hollowcube.mapmaker.kafka.BaseConsumer;
 import net.hollowcube.mapmaker.util.AbstractHttpService;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -25,10 +24,9 @@ public abstract class MapMgmtConsumer extends BaseConsumer<MapMgmtConsumer.MapUp
     }
 
     private static final String TOPIC_NAME = "map_mgmt";
-    private static final String GROUP_ID = ServerRuntime.getRuntime().hostname();
 
     public MapMgmtConsumer(@NotNull String bootstrapServers) {
-        super(TOPIC_NAME, GROUP_ID, MapUpdateMessage::fromJson, bootstrapServers);
+        super(TOPIC_NAME, MapUpdateMessage::fromJson, bootstrapServers);
         setAutocommit(false);
     }
 

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/map/MapPlayerDataMgmtConsumer.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/map/MapPlayerDataMgmtConsumer.java
@@ -1,6 +1,5 @@
 package net.hollowcube.mapmaker.map;
 
-import net.hollowcube.common.ServerRuntime;
 import net.hollowcube.mapmaker.kafka.BaseConsumer;
 import net.hollowcube.mapmaker.util.AbstractHttpService;
 import net.minestom.server.MinecraftServer;
@@ -27,10 +26,9 @@ public class MapPlayerDataMgmtConsumer extends BaseConsumer<MapPlayerDataMgmtCon
     }
 
     private static final String TOPIC_NAME = "map_player_data_mgmt";
-    private static final String GROUP_ID = ServerRuntime.getRuntime().hostname();
 
     public MapPlayerDataMgmtConsumer(@NotNull String bootstrapServers) {
-        super(TOPIC_NAME, GROUP_ID, MapPlayerDataUpdateMessage::fromJson, bootstrapServers);
+        super(TOPIC_NAME, MapPlayerDataUpdateMessage::fromJson, bootstrapServers);
         setAutocommit(false);
     }
 

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/player/SessionServiceImpl.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/player/SessionServiceImpl.java
@@ -1,6 +1,7 @@
 package net.hollowcube.mapmaker.player;
 
 import com.google.gson.reflect.TypeToken;
+import net.hollowcube.common.ServerRuntime;
 import net.hollowcube.mapmaker.session.PlayerSession;
 import net.hollowcube.mapmaker.util.AbstractHttpService;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +40,7 @@ public class SessionServiceImpl extends AbstractHttpService implements SessionSe
     @Override
     public @NotNull PlayerDataV2 createSession(@NotNull String id, @NotNull String username, @NotNull String ip) {
         logger.log(System.Logger.Level.INFO, "creating new session for {0} ({1})", id, username, ip);
-        var reqBody = GSON.toJson(new SessionCreateRequest(hostname, username, ip));
+        var reqBody = GSON.toJson(new SessionCreateRequest(ServerRuntime.getRuntime().hostname(), username, ip));
         var req = HttpRequest.newBuilder()
                 .method("POST", HttpRequest.BodyPublishers.ofString(reqBody))
                 .uri(URI.create(url + "/" + id))

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/session/SessionManager.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/session/SessionManager.java
@@ -146,7 +146,7 @@ public class SessionManager {
     private class ConsumerImpl extends BaseConsumer<SessionUpdateMessage> {
 
         protected ConsumerImpl(@NotNull String bootstrapServers) {
-            super("session-updates", AbstractHttpService.hostname, s -> AbstractHttpService.GSON.fromJson(s, SessionUpdateMessage.class), bootstrapServers);
+            super("session-updates", s -> AbstractHttpService.GSON.fromJson(s, SessionUpdateMessage.class), bootstrapServers);
         }
 
         @Override

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/util/AbstractHttpService.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/util/AbstractHttpService.java
@@ -20,8 +20,6 @@ import net.minestom.server.item.Material;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -60,8 +58,6 @@ public abstract class AbstractHttpService {
             .disableJdkUnsafe()
             .create();
 
-    public static final String hostname; //todo replace me with ServerRuntime call
-
     private final HttpClient httpClient = HttpClient.newHttpClient();
 
     protected <T> HttpResponse<T> doRequest(@NotNull HttpRequest req, HttpResponse.BodyHandler<T> handler) {
@@ -81,15 +77,4 @@ public abstract class AbstractHttpService {
             throw new MapService.InternalError(e);
         }
     }
-
-    static {
-        String hn;
-        try {
-            hn = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            hn = "unknown";
-        }
-        hostname = hn;
-    }
-
 }

--- a/modules/map/src/main/java/net/hollowcube/mapmaker/map/MapServerRunner.java
+++ b/modules/map/src/main/java/net/hollowcube/mapmaker/map/MapServerRunner.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -56,6 +57,7 @@ public class MapServerRunner extends AbstractMapServer {
 
     private MapJoinConsumer mapJoinConsumer;
     private Terraform terraform;
+    private final ServerRuntime runtime;
 
     private FeatureList features;
 
@@ -70,6 +72,9 @@ public class MapServerRunner extends AbstractMapServer {
 
     public MapServerRunner(@NotNull ConfigLoaderV3 config) {
         super(config);
+
+        // Runtime init
+        runtime = ServiceLoader.load(ServerRuntime.class).findFirst().orElseThrow();
 
         MinecraftServer.getGlobalEventHandler().addChild(EventNode.all("hub-init")
                 .addListener(AsyncPlayerConfigurationEvent.class, this::handleConfigPhase)
@@ -94,7 +99,7 @@ public class MapServerRunner extends AbstractMapServer {
 
     @Override
     protected @NotNull ServerBridge createBridge() {
-        return globalConfig.noop() ? new NoopServerBridge() : new MapServerBridge(this);
+        return globalConfig.noop() ? new NoopServerBridge() : new MapServerBridge(this, runtime);
     }
 
     @Override
@@ -270,12 +275,12 @@ public class MapServerRunner extends AbstractMapServer {
     private class MapJoinConsumer extends BaseConsumer<MapJoinInfoMessage> {
 
         protected MapJoinConsumer(@NotNull String bootstrapServers) {
-            super("map-join", AbstractHttpService.hostname, s -> AbstractHttpService.GSON.fromJson(s, MapJoinInfoMessage.class), bootstrapServers);
+            super("map-join", s -> AbstractHttpService.GSON.fromJson(s, MapJoinInfoMessage.class), bootstrapServers);
         }
 
         @Override
         protected void onMessage(@NotNull ConsumerRecord<String, String> kafkaRecord, @NotNull MapJoinInfoMessage message) {
-            if (!AbstractHttpService.hostname.equals(message.serverId())) return; // Not for this server, ignore.
+            if (!runtime.hostname().equals(message.serverId())) return; // Not for this server, ignore.
 
             logger.info("received join info for {}: {}", message.playerId(), message);
             var pendingJoin = getPendingJoin(message.playerId(), true);

--- a/modules/map/src/main/java/net/hollowcube/mapmaker/map/feature/edit/SchematicUploadFeatureProvider.java
+++ b/modules/map/src/main/java/net/hollowcube/mapmaker/map/feature/edit/SchematicUploadFeatureProvider.java
@@ -2,13 +2,13 @@ package net.hollowcube.mapmaker.map.feature.edit;
 
 import com.google.auto.service.AutoService;
 import net.hollowcube.common.ServerRuntime;
-import net.hollowcube.mapmaker.map.feature.FeatureProvider;
-import net.hollowcube.mapmaker.map.util.MapMessages;
-import net.hollowcube.mapmaker.map.world.EditingMapWorld;
-import net.hollowcube.mapmaker.map.MapWorld;
 import net.hollowcube.mapmaker.config.ConfigLoaderV3;
 import net.hollowcube.mapmaker.kafka.BaseConsumer;
 import net.hollowcube.mapmaker.kafka.FriendlyProducer;
+import net.hollowcube.mapmaker.map.MapWorld;
+import net.hollowcube.mapmaker.map.feature.FeatureProvider;
+import net.hollowcube.mapmaker.map.util.MapMessages;
+import net.hollowcube.mapmaker.map.world.EditingMapWorld;
 import net.hollowcube.mapmaker.to_be_refactored.model.kafka.SchematicMgmt;
 import net.hollowcube.terraform.schem.Schematic;
 import net.hollowcube.terraform.schem.SchematicReadException;
@@ -53,12 +53,11 @@ public class SchematicUploadFeatureProvider implements FeatureProvider {
         private static final System.Logger logger = System.getLogger(SchematicUploadConsumer.class.getName());
 
         private static final String TOPIC_NAME = "schematic-mgmt";
-        private static final String GROUP_ID = ServerRuntime.getRuntime().hostname();
 
         private static final byte[] ERR_NOT_EDITING = "You are not currently editing a map.".getBytes(StandardCharsets.UTF_8);
 
         protected SchematicUploadConsumer(@NotNull String bootstrapServers) {
-            super(TOPIC_NAME, GROUP_ID, SchematicMgmt::fromJson, bootstrapServers);
+            super(TOPIC_NAME, SchematicMgmt::fromJson, bootstrapServers);
             setAutocommit(false);
         }
 

--- a/modules/map/src/main/java/net/hollowcube/mapmaker/map/runtime/MapServerBridge.java
+++ b/modules/map/src/main/java/net/hollowcube/mapmaker/map/runtime/MapServerBridge.java
@@ -1,11 +1,11 @@
 package net.hollowcube.mapmaker.map.runtime;
 
+import net.hollowcube.common.ServerRuntime;
 import net.hollowcube.mapmaker.map.MapServerRunner;
 import net.hollowcube.mapmaker.player.JoinHubRequest;
 import net.hollowcube.mapmaker.player.JoinMapRequest;
 import net.hollowcube.mapmaker.player.PlayerDataV2;
 import net.hollowcube.mapmaker.session.MapPresence;
-import net.hollowcube.mapmaker.util.AbstractHttpService;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
@@ -19,9 +19,11 @@ public class MapServerBridge implements ServerBridge {
     private static final Logger logger = LoggerFactory.getLogger(MapServerBridge.class);
 
     private final MapServerRunner server;
+    private final ServerRuntime runtime;
 
-    public MapServerBridge(@NotNull MapServerRunner server) {
+    public MapServerBridge(@NotNull MapServerRunner server, @NotNull ServerRuntime runtime) {
         this.server = server;
+        this.runtime = runtime;
     }
 
     @Override
@@ -38,8 +40,7 @@ public class MapServerBridge implements ServerBridge {
             var response = server.sessionService().joinMapV2(new JoinMapRequest(playerId, mapId, targetState));
             logger.info("join map result: {}", response);
 
-            var currentServerId = AbstractHttpService.hostname;
-            if (currentServerId.equals(response.server())) {
+            if (runtime.hostname().equals(response.server())) {
                 logger.info("moving between maps on this server");
                 this.moveBetweenMapsOnThisServer(player, mapId, targetState);
             } else {


### PR DESCRIPTION
Replaced AbstractHttpService.hostname usage with ServerRuntime hostname, as well as removing an unused groupId parameter from BaseConsumer.