### PR TITLE
Progress index addition mode

### DIFF
--- a/bin/development/src/main/java/net/hollowcube/mapmaker/dev/DevServerRunner.java
+++ b/bin/development/src/main/java/net/hollowcube/mapmaker/dev/DevServerRunner.java
@@ -7,7 +7,9 @@ import net.hollowcube.mapmaker.config.ConfigLoaderV3;
 import net.hollowcube.mapmaker.hub.HubMapWorld;
 import net.hollowcube.mapmaker.hub.HubServerRunner;
 import net.hollowcube.mapmaker.map.MapServerRunner;
+import net.hollowcube.mapmaker.map.MapSettings;
 import net.hollowcube.mapmaker.map.MapWorld;
+import net.hollowcube.mapmaker.map.command.DebugCommand;
 import net.hollowcube.mapmaker.map.feature.FeatureList;
 import net.hollowcube.mapmaker.map.hdb.HeadDatabase;
 import net.hollowcube.mapmaker.map.runtime.AbstractMapServer;
@@ -212,5 +214,27 @@ public class DevServerRunner extends AbstractMapServer {
 
         // Again, need to implement the proxy part of the delete session flow
         sessionService().deleteSessionV2(player.getUuid().toString());
+    }
+
+    @Override
+    protected @NotNull DebugCommand createDebugCommand() {
+        DebugCommand dbg = super.createDebugCommand();
+
+        dbg.createPermissionedSubcommand("enableprogressaddition", (player, context) -> {
+            var world = MapWorld.forPlayerOptional(player);
+            if (world == null) {
+                player.sendMessage("You are not in a map world!");
+                return;
+            }
+
+            if (world instanceof EditingMapWorld && world.canEdit(player)) {
+                world.map().setSetting(MapSettings.PROGRESS_INDEX_ADDITION, true);
+                player.sendMessage("Enabled progress addition");
+            } else {
+                player.sendMessage("You are not in an editing world!");
+            }
+        }, "Enables progress index add mode for the current map");
+
+        return dbg;
     }
 }

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/map/MapSettings.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/map/MapSettings.java
@@ -30,6 +30,9 @@ public class MapSettings {
     public static final MapSetting<TimeOfDay> TIME_OF_DAY = MapSetting.Enum("time_of_day", TimeOfDay.NOON);
     public static final MapSetting<WeatherType> WEATHER_TYPE = MapSetting.Enum("weather_type", WeatherType.CLEAR);
 
+    // Weird/one off/experimental settings
+    public static final MapSetting<Boolean> PROGRESS_INDEX_ADDITION = MapSetting.Bool("progress_index_addition", false);
+
     transient MapUpdateRequest updates = new MapUpdateRequest();
     transient ReentrantLock updateLock = new ReentrantLock();
 

--- a/modules/map/src/main/java/net/hollowcube/mapmaker/map/MapServerRunner.java
+++ b/modules/map/src/main/java/net/hollowcube/mapmaker/map/MapServerRunner.java
@@ -309,6 +309,21 @@ public class MapServerRunner extends AbstractMapServer {
             player.sendMessage("Type: " + world.getClass().getSimpleName());
         }, "Shows information about the world you are in");
 
+        cmd.createPermissionedSubcommand("enableprogressaddition", (player, context) -> {
+            var world = MapWorld.forPlayerOptional(player);
+            if (world == null) {
+                player.sendMessage("You are not in a map world!");
+                return;
+            }
+
+            if (world instanceof EditingMapWorld && world.canEdit(player)) {
+                world.map().setSetting(MapSettings.PROGRESS_INDEX_ADDITION, true);
+                player.sendMessage("Enabled progress addition");
+            } else {
+                player.sendMessage("You are not in an editing world!");
+            }
+        }, "Enables progress index add mode for the current map");
+
         return cmd;
     }
 

--- a/modules/map/src/main/java/net/hollowcube/mapmaker/map/feature/play/BaseParkourMapFeatureProvider.java
+++ b/modules/map/src/main/java/net/hollowcube/mapmaker/map/feature/play/BaseParkourMapFeatureProvider.java
@@ -197,7 +197,7 @@ public class BaseParkourMapFeatureProvider implements FeatureProvider {
 
             // If this is a fresh save state, attempt to add the base effect state
             if (world.hasTag(SPAWN_CHECKPOINT_EFFECTS) && saveState.getPlayStartTime() == 0) {
-                updateCheckpointEffectState(player, world.getTag(SPAWN_CHECKPOINT_EFFECTS), playState);
+                updateCheckpointEffectState(world, player, world.getTag(SPAWN_CHECKPOINT_EFFECTS), playState);
             }
 
             updatePlayerFromState(player, playState);
@@ -295,7 +295,7 @@ public class BaseParkourMapFeatureProvider implements FeatureProvider {
         state.setTimeLimit(-1); // Time always reset on checkpoint
         player.removeTag(COUNTDOWN_END);
         updateStateFromPlayer(player, state);
-        updateCheckpointEffectState(player, data, state);
+        updateCheckpointEffectState(MapWorld.forPlayer(player), player, data, state);
 
         // Cache the last state so that we can reset back here.
         state.setLastState(new PlayState(
@@ -336,7 +336,7 @@ public class BaseParkourMapFeatureProvider implements FeatureProvider {
 
         // Apply the status changes
         updateStateFromPlayer(player, state);
-        updateBaseEffectState(player, data, state);
+        updateBaseEffectState(MapWorld.forPlayer(player), player, data, state);
         if (data.extraTime() > 0 && state.timeLimit().isPresent()) {
             state.setTimeLimit(state.timeLimit().get() + data.extraTime());
         }
@@ -502,8 +502,8 @@ public class BaseParkourMapFeatureProvider implements FeatureProvider {
         });
     }
 
-    private void updateCheckpointEffectState(@NotNull Player player, @NotNull CheckpointEffectData data, @NotNull PlayState state) {
-        updateBaseEffectState(player, data, state);
+    private void updateCheckpointEffectState(@NotNull MapWorld world, @NotNull Player player, @NotNull CheckpointEffectData data, @NotNull PlayState state) {
+        updateBaseEffectState(world, player, data, state);
         if (data.lives() > 0) {
             state.setMaxLives(data.lives());
             state.setLives(data.lives());
@@ -513,9 +513,10 @@ public class BaseParkourMapFeatureProvider implements FeatureProvider {
         }
     }
 
-    private void updateBaseEffectState(@NotNull Player player, @NotNull BaseEffectData data, @NotNull PlayState state) {
+    private void updateBaseEffectState(@NotNull MapWorld world, @NotNull Player player, @NotNull BaseEffectData data, @NotNull PlayState state) {
         if (data.progressIndex() != -1) {
-            state.setProgressIndex(data.progressIndex());
+            boolean useProgressAddition = world.map().getSetting(MapSettings.PROGRESS_INDEX_ADDITION);
+            state.setProgressIndex(useProgressAddition ? (state.progressIndex().orElse(0) + data.progressIndex()) : data.progressIndex());
         }
         if (data.timeLimit() > 0) {
             // Only update the time limit if it is assigned in this effect.


### PR DESCRIPTION
Adding to solve Ollie's problem of required checkpoint groups. It is not enabled anywhere by default and cannot be edited by users.

Staff can enable it in a map by doing `/debug enableprogressaddition` while editing the map. You will need to go to hub and back for the change to take effect.