### PR TITLE
feat: make TF wand unable to break blocks

### DIFF
--- a/modules/terraform/src/main/java/net/hollowcube/terraform/tool/BuiltinTool.java
+++ b/modules/terraform/src/main/java/net/hollowcube/terraform/tool/BuiltinTool.java
@@ -37,6 +37,10 @@ public interface BuiltinTool {
 
     @NotNull Material material();
 
+    default @NotNull ItemStack.Builder createItemStack() {
+        return ItemStack.builder(material());
+    }
+
 
     void leftClicked(@NotNull Click click);
 

--- a/modules/terraform/src/main/java/net/hollowcube/terraform/tool/ToolHandler.java
+++ b/modules/terraform/src/main/java/net/hollowcube/terraform/tool/ToolHandler.java
@@ -67,8 +67,9 @@ public class ToolHandler {
     public @NotNull ItemStack createBuiltinTool(@NotNull Key key) {
         var tool = tools.get(key.asString());
         Check.notNull(tool, "missing tool: " + key.asString());
-        return ItemStack.of(tool.material())
-                .withTag(BuiltinTool.TYPE, key.asString());
+        return tool.createItemStack()
+                .set(BuiltinTool.TYPE, key.asString())
+                .build();
     }
 
     private void handleBreakBlock(@NotNull PlayerBlockBreakEvent event) {

--- a/modules/terraform/src/main/java/net/hollowcube/terraform/tool/WandTool.java
+++ b/modules/terraform/src/main/java/net/hollowcube/terraform/tool/WandTool.java
@@ -5,8 +5,13 @@ import net.hollowcube.terraform.selection.Selection;
 import net.hollowcube.terraform.session.LocalSession;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.minestom.server.component.DataComponents;
+import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.minestom.server.item.component.Tool;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 @AutoService(BuiltinTool.class)
 public class WandTool implements BuiltinTool {
@@ -25,6 +30,12 @@ public class WandTool implements BuiltinTool {
     @Override
     public @NotNull Material material() {
         return Material.WOODEN_AXE;
+    }
+
+    @Override
+    public @NotNull ItemStack.Builder createItemStack() {
+        return BuiltinTool.super.createItemStack()
+                .set(DataComponents.TOOL, new Tool(List.of(), 0f, 0, false));
     }
 
     @Override


### PR DESCRIPTION
Makes the wand unable to break blocks similar to swords in creative so that Right and left click feel the same, idk if everyone feels the same about this but it felt better when using it