### PR TITLE
fix: handle and exclude dotless sound keys (intentionally_empty)

### DIFF
--- a/modules/core/src/main/java/net/hollowcube/mapmaker/command/playerinfo/TopTimesInfoType.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/command/playerinfo/TopTimesInfoType.java
@@ -22,6 +22,8 @@ import java.util.List;
 import static net.hollowcube.mapmaker.util.NumberUtil.formatMapPlaytime;
 
 public class TopTimesInfoType extends CommandDsl {
+    private static final int PAGE_SIZE = 15;
+
     private final ApiClient api;
 
     private final Argument<String> targetArgument;
@@ -48,8 +50,8 @@ public class TopTimesInfoType extends CommandDsl {
         }
         Component targetName = api.players.getDisplayName(targetId).asComponent();
 
-        var resp = api.maps.getPlayerTopTimes(targetId, page - 1, 15);
-        int maxPage = Math.ceilDiv(resp.count(), 15);
+        var resp = api.maps.getPlayerTopTimes(targetId, page - 1, PAGE_SIZE);
+        int maxPage = Math.ceilDiv(resp.count(), PAGE_SIZE);
         if (maxPage == 0) {
             sender.sendMessage(targetName.append(Component.text(" has no top times")));
             return;
@@ -57,11 +59,11 @@ public class TopTimesInfoType extends CommandDsl {
 
         if (page > maxPage) {
             page = maxPage;
-            resp = api.maps.getPlayerTopTimes(targetId, page - 1, 15);
+            resp = api.maps.getPlayerTopTimes(targetId, page - 1, PAGE_SIZE);
         }
 
         sender.sendMessage(targetName.append(
-            Component.text("'s Top Times (%s/%s):".formatted(page, Math.ceilDiv(resp.count(), 15)))));
+            Component.text("'s Top Times (%s/%s):".formatted(page, Math.ceilDiv(resp.count(), PAGE_SIZE)))));
         List<LeaderboardData.Entry> entries = new ArrayList<>();
         for (PlayerTopTimeEntry entry : resp.results()) {
             entries.add(

--- a/modules/core/src/main/java/net/hollowcube/mapmaker/util/Autocompletors.java
+++ b/modules/core/src/main/java/net/hollowcube/mapmaker/util/Autocompletors.java
@@ -37,6 +37,8 @@ public final class Autocompletors {
         }
         for (var sound : SoundEvent.values()) {
             if (!(sound instanceof BuiltinSoundEvent event)) continue;
+            // Placeholder "no sound" event, not a real selectable sound.
+            if (sound == SoundEvent.INTENTIONALLY_EMPTY) continue;
             sounds.add(new IndexableProtocolObject<>(event));
         }
     }

--- a/modules/map-runtime/src/main/java/net/hollowcube/mapmaker/runtime/parkour/action/gui/editors/PlaySoundEditor.java
+++ b/modules/map-runtime/src/main/java/net/hollowcube/mapmaker/runtime/parkour/action/gui/editors/PlaySoundEditor.java
@@ -82,10 +82,14 @@ public class PlaySoundEditor extends AbstractActionEditorPanel<@NotNull PlaySoun
 
         var id = sound.key().asMinimalString();
 
-        var key = id.substring(0, id.indexOf('.'));
-        var path = id.indexOf('.', key.length() + 1) != -1 ?
-            id.substring(key.length() + 1, id.indexOf('.', key.length() + 1)) :
-            id.substring(key.length() + 1);
+        // Some sound keys have no category prefix (e.g. "intentionally_empty"), so there may
+        // be no '.' to split on. Treat the whole id as the key, which falls through to the
+        // default icon in the switch below.
+        var firstDot = id.indexOf('.');
+        var key = firstDot == -1 ? id : id.substring(0, firstDot);
+        var secondDot = firstDot == -1 ? -1 : id.indexOf('.', firstDot + 1);
+        var path = firstDot == -1 ? "" :
+            secondDot != -1 ? id.substring(firstDot + 1, secondDot) : id.substring(firstDot + 1);
         var icon = switch (key) {
             case "block" -> OpUtils.mapOr(Block.fromKey(path), it -> it.registry().material(), Material.BARRIER);
             case "entity" -> {


### PR DESCRIPTION
## Problem

Selecting/rendering the `minecraft:intentionally_empty` sound in the action editor crashed a scheduled task with:

```
java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 19
  at net.hollowcube.mapmaker.runtime.parkour.action.gui.editors.PlaySoundEditor.makeSoundButton (line 85)
```

`makeSoundButton` parses a sound's minimal key as `category.path…` to pick an icon, assuming every key contains a `.`:

```java
var key = id.substring(0, id.indexOf('.'));
```

`intentionally_empty` (`asMinimalString()` → `intentionally_empty`, 19 chars, no dot) is a placeholder "no sound" event that has no category prefix, so `indexOf('.')` returns `-1` and `substring(0, -1)` throws. It surfaced inside the debounced anvil-search update, hence "Exception in scheduled task."

## Fix

- **`PlaySoundEditor.makeSoundButton`** — guard the dotless case: the whole id is used as the key and falls through to the default icon. Also computes each `indexOf` once instead of recomputing the second dot. Defends against any other dotless sound key.
- **`Autocompletors`** — exclude `SoundEvent.INTENTIONALLY_EMPTY` when building the sound search index, so the no-op placeholder sound never appears as a pickable option in the first place.

Both modules compile clean.

## PostHog issue

https://us.posthog.com/project/72878/error_tracking/019cf337-116b-7323-a8b6-6baeba2d2630