### PR TITLE
fix: initialize Minestom LoginListener at run time for native image

### DIFF
--- a/tools/native-image-helper/src/main/java/net/hollowcube/nativeimage/HCNativeImageFeature.java
+++ b/tools/native-image-helper/src/main/java/net/hollowcube/nativeimage/HCNativeImageFeature.java
@@ -74,6 +74,10 @@ public class HCNativeImageFeature implements Feature {
             RuntimeClassInitialization.initializeAtRunTime(access.findClassByName("net.minestom.server.network.player.PlayerSocketConnection"));
             RuntimeClassInitialization.initializeAtRunTime(access.findClassByName("net.minestom.server.network.packet.PacketVanilla"));
 
+            // LoginListener holds a static SecureRandom. GraalVM disallows Random/SecureRandom instances in the
+            // image heap entirely, so it must not be initialized at build time by the blanket net.minestom init.
+            RuntimeClassInitialization.initializeAtRunTime(access.findClassByName("net.minestom.server.listener.preplay.LoginListener"));
+
             // https://github.com/nats-io/nats.java#integration-with-graalvm
             RuntimeClassInitialization.initializeAtRunTime(access.findClassByName("java.security.SecureRandom"));
             RuntimeClassInitialization.initializeAtRunTime(access.findClassByName("io.nats.client.support.RandomUtils"));


### PR DESCRIPTION
## Problem

The `map-isolate` native image build fails during analysis:

```
Detected an instance of Random/SplittableRandom class in the image heap.
  scanning root java.security.SecureRandom@...: NativePRNG embedded in
    net.minestom.server.listener.preplay.LoginListener.loginStartListener(LoginListener.java:79)
```

Minestom's `LoginListener` holds a `static SecureRandom`. `HCNativeImageFeature` blanket-initializes every `net.minestom.*` package at build time, so that field is constructed during image generation and lands in the image heap — which GraalVM forbids for `Random`/`SecureRandom` (cached seed values). This surfaced after the recent Minestom update.

A `--initialize-at-build-time=java.security.SecureRandom` flag does **not** help — GraalVM's `DisallowedImageHeapObjects` check rejects such instances regardless of init policy. The instance simply must not be created at build time.

## Fix

Initialize `LoginListener` at run time so its `SecureRandom` is never constructed during image generation. This follows the existing precedent in the same file (`PlayerSocketConnection`, `NetworkBufferImpl`, etc. are already runtime-init'd to override the blanket package init).

## Verification

`./gradlew :bin:map-isolate:nativeCompile` now succeeds locally (`Finished generating 'map-isolate' in 2m 46s`, 125 MB executable produced).