### PR TITLE
Fix flipped clipboard paste position and mirror block states

### DIFF
--- a/modules/terraform/src/main/java/net/hollowcube/terraform/util/transformations/FlipSchematicTransformation.java
+++ b/modules/terraform/src/main/java/net/hollowcube/terraform/util/transformations/FlipSchematicTransformation.java
@@ -22,9 +22,9 @@ public record FlipSchematicTransformation(boolean x, boolean y, boolean z) imple
         int pz = pivot.blockZ();
 
         return new Vec(
-                this.x ? -point.blockX() + px : point.blockX(),
-                this.y ? -point.blockY() + py : point.blockY(),
-                this.z ? -point.blockZ() + pz : point.blockZ()
+                this.x ? 2 * px - point.blockX() : point.blockX(),
+                this.y ? 2 * py - point.blockY() : point.blockY(),
+                this.z ? 2 * pz - point.blockZ() : point.blockZ()
         );
     }
 }

--- a/modules/terraform/src/main/java/net/hollowcube/terraform/util/transformations/FlipSchematicTransformation.java
+++ b/modules/terraform/src/main/java/net/hollowcube/terraform/util/transformations/FlipSchematicTransformation.java
@@ -1,9 +1,15 @@
 package net.hollowcube.terraform.util.transformations;
 
+import net.hollowcube.common.util.PropertyUtil;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Represents a transformation that flips the schematic across specified axes.
@@ -12,7 +18,56 @@ public record FlipSchematicTransformation(boolean x, boolean y, boolean z) imple
 
     @Override
     public @NotNull Block apply(@NotNull Block block) {
-        return block;
+        Map<String, String> properties = block.properties();
+        if (properties.isEmpty()) return block;
+        Map<String, String> newProperties = new HashMap<>();
+
+        var facing = PropertyUtil.getFacing(properties);
+        if (facing != null) newProperties.put("facing", mirror(facing).name().toLowerCase(Locale.ROOT));
+
+        var rotation = PropertyUtil.getRotation(properties);
+        if (rotation != null) newProperties.put("rotation", String.valueOf(mirror((int) rotation)));
+
+        var connections = PropertyUtil.getConnections(properties);
+        if (connections != null) {
+            for (var entry : mirror(connections).entrySet()) {
+                newProperties.put(entry.getKey().name().toLowerCase(Locale.ROOT), entry.getValue());
+            }
+        }
+
+        var shape = properties.get("shape");
+        if (shape != null) newProperties.put("shape", mirrorShape(shape));
+
+        // A single horizontal mirror swaps left and right handed states; mirroring
+        // both horizontal axes is a 180 degree rotation, which preserves them.
+        if (this.x ^ this.z) {
+            swap(properties, newProperties, "hinge", "left", "right");
+            swap(properties, newProperties, "type", "left", "right");
+        }
+        if (this.y) {
+            swap(properties, newProperties, "half", "top", "bottom");
+            swap(properties, newProperties, "half", "upper", "lower");
+            swap(properties, newProperties, "type", "top", "bottom");
+            swap(properties, newProperties, "face", "floor", "ceiling");
+            swap(properties, newProperties, "attachment", "floor", "ceiling");
+            var up = properties.get("up");
+            var down = properties.get("down");
+            if (up != null && down != null) {
+                newProperties.put("up", down);
+                newProperties.put("down", up);
+            }
+        }
+
+        // Apply properties individually since a mirrored value may not exist for a
+        // given block (e.g. hoppers cannot face up); such values are kept as-is.
+        var result = block;
+        for (var entry : newProperties.entrySet()) {
+            try {
+                result = result.withProperty(entry.getKey(), entry.getValue());
+            } catch (RuntimeException ignored) {
+            }
+        }
+        return result;
     }
 
     @Override
@@ -26,5 +81,82 @@ public record FlipSchematicTransformation(boolean x, boolean y, boolean z) imple
                 this.y ? 2 * py - point.blockY() : point.blockY(),
                 this.z ? 2 * pz - point.blockZ() : point.blockZ()
         );
+    }
+
+    private @NotNull Direction mirror(@NotNull Direction direction) {
+        return switch (direction) {
+            case EAST, WEST -> this.x ? direction.opposite() : direction;
+            case UP, DOWN -> this.y ? direction.opposite() : direction;
+            case NORTH, SOUTH -> this.z ? direction.opposite() : direction;
+        };
+    }
+
+    private int mirror(int rotation) {
+        var result = rotation;
+        if (this.x) result = (16 - result) % 16;
+        if (this.z) result = (24 - result) % 16;
+        return result;
+    }
+
+    private @NotNull Map<Direction, String> mirror(@NotNull Map<Direction, String> connections) {
+        return Map.of(
+                Direction.NORTH, connections.get(mirror(Direction.NORTH)),
+                Direction.EAST, connections.get(mirror(Direction.EAST)),
+                Direction.SOUTH, connections.get(mirror(Direction.SOUTH)),
+                Direction.WEST, connections.get(mirror(Direction.WEST))
+        );
+    }
+
+    private @NotNull String mirrorShape(@NotNull String shape) {
+        var result = shape;
+        // Stair shapes are chiral, see the left/right handling above.
+        if (this.x ^ this.z) {
+            result = switch (result) {
+                case "inner_left" -> "inner_right";
+                case "inner_right" -> "inner_left";
+                case "outer_left" -> "outer_right";
+                case "outer_right" -> "outer_left";
+                default -> result;
+            };
+        }
+        // Rail shapes name absolute directions and mirror per axis.
+        if (this.x) {
+            result = switch (result) {
+                case "ascending_east" -> "ascending_west";
+                case "ascending_west" -> "ascending_east";
+                case "north_east" -> "north_west";
+                case "north_west" -> "north_east";
+                case "south_east" -> "south_west";
+                case "south_west" -> "south_east";
+                default -> result;
+            };
+        }
+        if (this.z) {
+            result = switch (result) {
+                case "ascending_north" -> "ascending_south";
+                case "ascending_south" -> "ascending_north";
+                case "north_east" -> "south_east";
+                case "south_east" -> "north_east";
+                case "north_west" -> "south_west";
+                case "south_west" -> "north_west";
+                default -> result;
+            };
+        }
+        if (this.y) {
+            result = switch (result) {
+                case "ascending_east" -> "ascending_west";
+                case "ascending_west" -> "ascending_east";
+                case "ascending_north" -> "ascending_south";
+                case "ascending_south" -> "ascending_north";
+                default -> result;
+            };
+        }
+        return result;
+    }
+
+    private static void swap(Map<String, String> properties, Map<String, String> newProperties, String key, String a, String b) {
+        var value = newProperties.getOrDefault(key, properties.get(key));
+        if (a.equals(value)) newProperties.put(key, b);
+        else if (b.equals(value)) newProperties.put(key, a);
     }
 }

--- a/modules/terraform/src/test/java/net/hollowcube/terraform/util/transformations/TestFlipSchematicTransformation.java
+++ b/modules/terraform/src/test/java/net/hollowcube/terraform/util/transformations/TestFlipSchematicTransformation.java
@@ -7,11 +7,60 @@ import net.hollowcube.test.TestEnv;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ServerTest
 class TestFlipSchematicTransformation {
+
+    private static final SchematicTransformation FLIP_X = SchematicTransformation.flip(true, false, false);
+    private static final SchematicTransformation FLIP_Y = SchematicTransformation.flip(false, true, false);
+    private static final SchematicTransformation FLIP_Z = SchematicTransformation.flip(false, false, true);
+    private static final SchematicTransformation FLIP_XZ = SchematicTransformation.flip(true, false, true);
+
+    private static Stream<Arguments> blockFlipSupplier() {
+        return Stream.of(
+                Arguments.of("Facing mirrored", FLIP_X,
+                        Block.FURNACE.withProperty("facing", "east"),
+                        Block.FURNACE.withProperty("facing", "west")),
+                Arguments.of("Sign rotation mirrored", FLIP_X,
+                        Block.OAK_SIGN.withProperty("rotation", "4"),
+                        Block.OAK_SIGN.withProperty("rotation", "12")),
+                Arguments.of("Fence connections swapped", FLIP_X,
+                        Block.ACACIA_FENCE.withProperties(Map.of("east", "true", "west", "false", "north", "true")),
+                        Block.ACACIA_FENCE.withProperties(Map.of("east", "false", "west", "true", "north", "true"))),
+                Arguments.of("Stair facing and shape mirrored", FLIP_X,
+                        Block.OAK_STAIRS.withProperties(Map.of("facing", "east", "shape", "inner_left")),
+                        Block.OAK_STAIRS.withProperties(Map.of("facing", "west", "shape", "inner_right"))),
+                Arguments.of("Double horizontal flip preserves chirality", FLIP_XZ,
+                        Block.OAK_STAIRS.withProperties(Map.of("facing", "east", "shape", "inner_left")),
+                        Block.OAK_STAIRS.withProperties(Map.of("facing", "west", "shape", "inner_left"))),
+                Arguments.of("Door hinge mirrored", FLIP_Z,
+                        Block.OAK_DOOR.withProperties(Map.of("facing", "north", "hinge", "left")),
+                        Block.OAK_DOOR.withProperties(Map.of("facing", "south", "hinge", "right"))),
+                Arguments.of("Stair half swapped vertically", FLIP_Y,
+                        Block.OAK_STAIRS.withProperties(Map.of("facing", "east", "half", "bottom")),
+                        Block.OAK_STAIRS.withProperties(Map.of("facing", "east", "half", "top"))),
+                Arguments.of("Rail corner mirrored", FLIP_X,
+                        Block.RAIL.withProperty("shape", "south_east"),
+                        Block.RAIL.withProperty("shape", "south_west")),
+                Arguments.of("Invalid mirrored value kept as-is", FLIP_Y,
+                        Block.HOPPER.withProperty("facing", "down"),
+                        Block.HOPPER.withProperty("facing", "down"))
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("blockFlipSupplier")
+    void testBlockFlip(String name, SchematicTransformation transformation, Block input, Block expected) {
+        assertEquals(expected, transformation.apply(input));
+    }
 
     // Regression test for #799: selection x=[10..14] copied while standing at
     // x=21 gives copy-relative positions x=[-11..-7]. Flipping must mirror the

--- a/modules/terraform/src/test/java/net/hollowcube/terraform/util/transformations/TestFlipSchematicTransformation.java
+++ b/modules/terraform/src/test/java/net/hollowcube/terraform/util/transformations/TestFlipSchematicTransformation.java
@@ -1,0 +1,35 @@
+package net.hollowcube.terraform.util.transformations;
+
+import net.hollowcube.schem.builder.SchematicBuilder;
+import net.hollowcube.terraform.session.Clipboard;
+import net.hollowcube.test.ServerTest;
+import net.hollowcube.test.TestEnv;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.instance.block.Block;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ServerTest
+class TestFlipSchematicTransformation {
+
+    // Regression test for #799: selection x=[10..14] copied while standing at
+    // x=21 gives copy-relative positions x=[-11..-7]. Flipping must mirror the
+    // strip across the copy origin to x=[7..11], not translate it further out.
+    @Test
+    void testFlipMirrorsAcrossCopyOrigin(TestEnv env) {
+        var builder = SchematicBuilder.builder();
+        for (int x = -11; x <= -7; x++) {
+            builder.block(new Vec(x, 0, 0), x == -7 ? Block.STONE : Block.DIRT);
+        }
+
+        var clipboard = new Clipboard("test");
+        clipboard.setData(builder.build());
+        clipboard.transform(SchematicTransformation.flip(true, false, false));
+
+        var flipped = clipboard.getTransformedSchematic();
+        assertEquals(new Vec(7, 0, 0), flipped.offset());
+        flipped.forEachBlock((pos, block) ->
+                assertEquals(pos.sameBlock(7, 0, 0) ? Block.STONE : Block.DIRT, block, pos.toString()));
+    }
+}


### PR DESCRIPTION
## Summary

Two changes to `//flip` (one per commit):

**Fix paste position (fixes #799).** `FlipSchematicTransformation` computed `-point + pivot`, which is not a mirror around the pivot — that is `2*pivot - point`. The missing pivot term left an uncancelled translation equal to the clipboard's copy offset, so pasting a flipped clipboard placed the region too far from the player along the flipped axis. Concretely: standing at x=21, copying x=[10..14], then `//flip west` + `//paste` landed the strip at x=[39..43] instead of the mirrored x=[28..32] (verified in game before/after). `RotateSchematicTransformation` already transforms around the pivot correctly; this brings flip in line with it.

**Mirror block states.** Flips previously left block states untouched, so stairs, doors, chests, etc. kept their original orientation after `//flip`. This mirrors `facing`, sign `rotation`, and connection properties per flipped axis, and handles chiral state: stair shapes, door hinges, and chest halves swap left/right on a single horizontal mirror but are preserved on a double x+z flip (which is a 180° rotation); rail shapes mirror by named direction; vertical flips swap `half`/`type`/`face`-style properties. Mirrored values that do not exist for a block (e.g. hoppers cannot face up) are kept as-is, matching vanilla behavior.

## Testing

- New `TestFlipSchematicTransformation`: one parameterized case per code branch of the block-state mirroring, plus a regression test for #799 reproducing the in-game scenario through `Clipboard#getTransformedSchematic`.
- Full `:modules:terraform:test` passes (the only failure is the pre-existing `TestSchematic.main`, which reads a hardcoded `/Users/matt/...` path).

Fixes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
